### PR TITLE
Fix cache via TOML update

### DIFF
--- a/workers/b2-proxy/wrangler.toml
+++ b/workers/b2-proxy/wrangler.toml
@@ -36,18 +36,13 @@ BUCKET_NAME = "#{B2_BUCKET_NAME}#"
 #
 # Note that HTTP headers are not case-sensitive. "host" will match "host",
 # "Host" and "HOST".
-#ALLOWED_HEADERS = [
-#    "content-type",
-#    "date",
-#    "host",
-#    "if-match",
-#    "if-modified-since",
-#    "if-none-match",
-#    "if-unmodified-since",
-#    "range",
-#    "x-amz-content-sha256",
-#    "x-amz-date",
-#    "x-amz-server-side-encryption-customer-algorithm",
-#    "x-amz-server-side-encryption-customer-key",
-#    "x-amz-server-side-encryption-customer-key-md5"
-#]
+ALLOWED_HEADERS = [
+  "content-type",
+  "date",
+  "host",
+  "if-match",
+  "if-modified-since",
+  "if-none-match",
+  "if-unmodified-since",
+  "range",
+]


### PR DESCRIPTION
Allows headers that the browser uses to deal with cache

remove amz headers